### PR TITLE
Add an option to prevent generating exact duplicates

### DIFF
--- a/tasks/rtlcss.js
+++ b/tasks/rtlcss.js
@@ -7,11 +7,11 @@
  */
 module.exports = function(grunt) {
 'use strict';
-    
+
   grunt.registerMultiTask('rtlcss', 'grunt plugin for rtlcss, a framework for transforming CSS from LTR to RTL.', function() {
-    
+
     var rtlcss = require('rtlcss');
-    
+
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({
       config:{
@@ -23,17 +23,18 @@ module.exports = function(grunt) {
         autoRename: true,
         greedy: false,
         enableLogging: false,
-        minify:false 
+        minify:false
       },
       rules:[],
       declarations:[],
       properties:[],
       map: false,
+      generateExactDuplicates: true,
     });
-    
+
     // postcss options
     var opt = { map: options.map, from:'', to:''};
-    
+
     // Iterate over all specified file groups.
     this.files.forEach(function(f) {
       // read specified files.
@@ -50,23 +51,27 @@ module.exports = function(grunt) {
         // Read file source.
         return grunt.file.read(filepath);
       });
-      
+
       // RTLCSS
       opt.to = f.dest;
       var result = rtlcss(options.config,
                              options.rules,
                              options.declarations,
                              options.properties).process(src,opt);
-      
-      // Write the destination file.
-      grunt.file.write(f.dest, result.css);
 
-      // Write the destination source map file.
-      if(options.map)
-        grunt.file.write(f.dest + '.map', result.map);
+      if(!options.generateExactDuplicates && result.css == src ) {
+         grunt.log.writeln('Nothing to flip in "' + f.src + '"' );
+      } else {
+        // Write the destination file.
+        grunt.file.write(f.dest, result.css);
 
-      // Print a success message.
-      grunt.log.writeln('File "' + f.dest + '" created.');
+        // Write the destination source map file.
+        if(options.map)
+          grunt.file.write(f.dest + '.map', result.map);
+
+        // Print a success message.
+        grunt.log.writeln('File "' + f.dest + '" created.');
+      }
     });
   });
 

--- a/tasks/rtlcss.js
+++ b/tasks/rtlcss.js
@@ -29,7 +29,7 @@ module.exports = function(grunt) {
       declarations:[],
       properties:[],
       map: false,
-      generateExactDuplicates: true,
+      saveUnmodified: true,
     });
 
     // postcss options
@@ -59,7 +59,7 @@ module.exports = function(grunt) {
                              options.declarations,
                              options.properties).process(src,opt);
 
-      if(!options.generateExactDuplicates && result.css == src ) {
+      if(!options.saveUnmodified && result.css == src ) {
          grunt.log.writeln('Nothing to flip in "' + f.src + '"' );
       } else {
         // Write the destination file.


### PR DESCRIPTION
I would like to introduce an option to prevent creating RTL files if the resulting CSS is just a duplicate of the LTR CSS. I named the option "generateExactDuplicates" which is by default true.
