### PR TITLE
Colorize file paths in log messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "rtlcss" : "^1.0.0"
+    "rtlcss": "^1.0.0",
+    "chalk": "~0.5.1"
   },
   "devDependencies": {
     "grunt": "~0.4.2"

--- a/tasks/rtlcss.js
+++ b/tasks/rtlcss.js
@@ -61,7 +61,7 @@ module.exports = function(grunt) {
                              options.properties).process(src,opt);
 
       if(!options.saveUnmodified && result.css == src ) {
-         grunt.log.writeln('Nothing to flip in ' + chalk.cyan(f.src) + '.' );
+         grunt.log.writeln('Skip saving unmodified file ' + chalk.cyan(f.src) + '.' );
       } else {
         // Write the destination file.
         grunt.file.write(f.dest, result.css);

--- a/tasks/rtlcss.js
+++ b/tasks/rtlcss.js
@@ -11,6 +11,7 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('rtlcss', 'grunt plugin for rtlcss, a framework for transforming CSS from LTR to RTL.', function() {
 
     var rtlcss = require('rtlcss');
+    var chalk = require('chalk');
 
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({
@@ -41,7 +42,7 @@ module.exports = function(grunt) {
       var src = f.src.filter(function(filepath) {
         // Warn on and remove invalid source files (if nonull was set).
         if (!grunt.file.exists(filepath)) {
-          grunt.log.warn('Source file "' + filepath + '" not found.');
+          grunt.log.warn('Source file ' + chalk.cyan(filepath) + ' not found.');
           return false;
         } else {
           return true;
@@ -60,7 +61,7 @@ module.exports = function(grunt) {
                              options.properties).process(src,opt);
 
       if(!options.saveUnmodified && result.css == src ) {
-         grunt.log.writeln('Skip saving unmodified file "' + f.src + '"' );
+         grunt.log.writeln('Nothing to flip in ' + chalk.cyan(f.src) + '.' );
       } else {
         // Write the destination file.
         grunt.file.write(f.dest, result.css);
@@ -70,7 +71,7 @@ module.exports = function(grunt) {
           grunt.file.write(f.dest + '.map', result.map);
 
         // Print a success message.
-        grunt.log.writeln('File "' + f.dest + '" created.');
+        grunt.log.writeln('File ' + chalk.cyan(f.dest) + ' created.');
       }
     });
   });


### PR DESCRIPTION
Just a minor thing I noticed when running multiple tasks in a row:

Before:
![before](https://cloud.githubusercontent.com/assets/617637/6200134/f5bab1ca-b46a-11e4-9709-b1db5526a924.png)

After:
![after](https://cloud.githubusercontent.com/assets/617637/6200137/fb88ae86-b46a-11e4-9d4d-cc8db129e255.png)

This adds [chalk](https://www.npmjs.com/package/chalk) as a dependency, which is also used by grunt-autoprefixer or grunt-contrib-cssmin.
